### PR TITLE
fix: wrong wrapper of branch

### DIFF
--- a/components/Github/RecentActivity/item.vue
+++ b/components/Github/RecentActivity/item.vue
@@ -23,10 +23,15 @@
                         Created New {{ items.ref?.type }} on
                         <component :is="createRepoLink(items.repo!)" />
 
-                        {{
-                            items.ref?.type === 'branch' ? `branch <span
-                        class="rounded bg-gray-700 px-1 py-0.5 font-[monospace] text-sm">${items.ref?.name}</span>` : ``
-                        }}
+                        <template v-if="items.ref?.type === 'branch'"
+                        >
+                            branch 
+                            <span 
+                                class="rounded bg-gray-700 px-1 py-0.5 font-[monospace] text-sm"
+                            >
+                                {{items.ref?.name}}
+                            </span>
+                        </template>
                     </template>
                     <template v-if="items.type === 'public'">
                         Made


### PR DESCRIPTION
<table>
<tr>
 <td>
 Before
 <td>
After
<tr>
 <td>
<img width="866" height="282" alt="CleanShot 2025-09-10 at 19 56 19@2x" src="https://github.com/user-attachments/assets/81bf66ae-e076-4120-ac1f-b6148e8767c4" />

 <td>
<img width="870" height="262" alt="CleanShot 2025-09-10 at 19 14 29@2x" src="https://github.com/user-attachments/assets/2110c1a5-6d60-4046-ab3d-62a7aa0d806e" />

</table>